### PR TITLE
feat: add CLIENT SETNAME to all Redis connections

### DIFF
--- a/apps/api/src/services/queue-service.ts
+++ b/apps/api/src/services/queue-service.ts
@@ -17,6 +17,7 @@ export function getRedisConnection(): IORedis {
   if (!redisConnection) {
     redisConnection = new IORedis(config.REDIS_URL!, {
       maxRetriesPerRequest: null,
+      connectionName: "firecrawl_queue_client",
     });
     redisConnection.on("connect", () => logger.info("Redis connected"));
     redisConnection.on("reconnecting", () => logger.warn("Redis reconnecting"));

--- a/apps/api/src/services/rate-limiter.ts
+++ b/apps/api/src/services/rate-limiter.ts
@@ -6,6 +6,7 @@ import type { AuthCreditUsageChunk } from "../controllers/v1/types";
 
 export const redisRateLimitClient = new Redis(config.REDIS_RATE_LIMIT_URL!, {
   enableAutoPipelining: true,
+  connectionName: "firecrawl_rate_limit_client",
 });
 
 const createRateLimiter = (keyPrefix, points) =>

--- a/apps/api/src/services/redis.ts
+++ b/apps/api/src/services/redis.ts
@@ -75,4 +75,5 @@ export { setValue, getValue, deleteKey };
 const redisEvictURL = config.REDIS_EVICT_URL ?? config.REDIS_RATE_LIMIT_URL;
 export const redisEvictConnection = new IORedis(redisEvictURL!, {
   enableAutoPipelining: true,
+  connectionName: "firecrawl_cache_client",
 });

--- a/apps/api/src/services/redlock.ts
+++ b/apps/api/src/services/redlock.ts
@@ -5,7 +5,9 @@ import Client from "ioredis";
 export const redlock = new Redlock(
   // You should have one client for each independent redis node
   // or cluster.
-  [new Client(config.REDIS_RATE_LIMIT_URL!)],
+  [new Client(config.REDIS_RATE_LIMIT_URL!, {
+    connectionName: "firecrawl_redlock_client",
+  })],
   {
     // The expected clock drift; for more details see:
     // http://redis.io/topics/distlock


### PR DESCRIPTION
## Summary

Adds `connectionName` to all ioredis client instances so that each connection identifies itself to the Redis/Valkey server via `CLIENT SETNAME`. This enables server-side monitoring and debugging of connections (e.g., via `CLIENT LIST`).

## Changes

| File | Connection Name | Purpose |
|------|----------------|---------|
| `apps/api/src/services/rate-limiter.ts` | `firecrawl_rate_limit_client` | Rate limiting |
| `apps/api/src/services/redis.ts` | `firecrawl_cache_client` | Cache eviction / general ops |
| `apps/api/src/services/queue-service.ts` | `firecrawl_queue_client` | BullMQ job queues |
| `apps/api/src/services/redlock.ts` | `firecrawl_redlock_client` | Distributed locking |

## Motivation

When running `CLIENT LIST` on a Redis/Valkey server, connections from Firecrawl currently show up unnamed, making it difficult to attribute connections to specific services or debug connection leaks. Setting `connectionName` (which maps to the Redis `CLIENT SETNAME` command) solves this.

## Risk

Zero-risk change — `connectionName` is a standard ioredis option that simply sends a `CLIENT SETNAME` command after connecting. No behavioral changes.

## Naming Convention

Follows the `{project}_{purpose}_client` pattern used across Valkey integrations.